### PR TITLE
updated ngwebdriver to 0.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>com.paulhammant</groupId>
       <artifactId>ngwebdriver</artifactId>
-      <version>0.9.6</version>
+      <version>0.9.7</version>
     </dependency>
     <dependency>
       <groupId>net.sf.uadetector</groupId>


### PR DESCRIPTION
This fixes the error that reads,

**TimeoutException: asynchronous script timeout: result was not received in 10 seconds**

that has been popping up quite frequently with frameworkium 2.0.6