### PR TITLE
Add ability to match node by applicationName

### DIFF
--- a/src/main/java/com/frameworkium/core/common/properties/Property.java
+++ b/src/main/java/com/frameworkium/core/common/properties/Property.java
@@ -30,6 +30,7 @@ public enum Property {
     CAPTURE_URL("captureURL"),
     GRID_URL("gridURL"),
     APP_PATH("appPath"),
+    APPLICATION_NAME("applicationName"),
     SAUCE("sauce"),
     BROWSER_STACK("browserStack"),
     MAXIMISE("maximise"),

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
@@ -9,9 +9,7 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static com.frameworkium.core.common.properties.Property.BROWSER_VERSION;
-import static com.frameworkium.core.common.properties.Property.PLATFORM;
-import static com.frameworkium.core.common.properties.Property.PLATFORM_VERSION;
+import static com.frameworkium.core.common.properties.Property.*;
 
 public class GridImpl extends AbstractDriver {
 
@@ -33,6 +31,9 @@ public class GridImpl extends AbstractDriver {
         }
         if (PLATFORM.isSpecified()) {
             desiredCapabilities.setCapability("platform", PLATFORM_VERSION.getValue());
+        }
+        if(APPLICATION_NAME.isSpecified()){
+            desiredCapabilities.setCapability("applicationName", APPLICATION_NAME.getValue());
         }
         return desiredCapabilities;
     }


### PR DESCRIPTION
frameworkium now has the capability to target specific nodes on the grid for test execution, 
by -DapplicationName=XXXX in your maven goal

--------------

In your node_5555.json, add

{"capabilities":[
{
...
...
...
"applicationName": "XXXX"
}
]}