### PR TITLE
Fix to ensure visibility of nested elements is correct

### DIFF
--- a/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
+++ b/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
@@ -10,6 +10,7 @@ import ru.yandex.qatools.htmlelements.element.HtmlElement;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -58,8 +59,20 @@ public final class Visibility {
      */
     public void waitForAnnotatedElementVisibility(Object pageObject) {
 
-        Field[] allFields = pageObject.getClass().getDeclaredFields();
-        Arrays.stream(allFields)
+    	Class <? extends Object> clazz = pageObject.getClass();
+    	// Get the declared fields from the current class
+    	final List<Field> allFields = new ArrayList<Field>(Arrays.asList(clazz.getDeclaredFields()));
+    	
+    	// Get any declared fields from super classes
+    	// i.e. when a page object extends a custom class which itself extends HtmlElement
+    	for(clazz = clazz.getSuperclass(); 
+    	    ((clazz != null) && (clazz != BasePage.class) && (clazz != HtmlElement.class));
+    		clazz = clazz.getSuperclass()) {
+    		Stream.of(clazz.getDeclaredFields()).
+    		        forEach(f->allFields.add(f));
+    	}
+    	        		
+        allFields.stream()
                 .filter(this::validateFieldVisibilityAnnotations)
                 .forEach(field ->
                         invokeWaitFunctionForField(field, pageObject));

--- a/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
+++ b/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
@@ -59,19 +59,19 @@ public final class Visibility {
      */
     public void waitForAnnotatedElementVisibility(Object pageObject) {
 
-    	Class <? extends Object> clazz = pageObject.getClass();
-    	// Get the declared fields from the current class
-    	final List<Field> allFields = new ArrayList<Field>(Arrays.asList(clazz.getDeclaredFields()));
-    	
-    	// Get any declared fields from super classes
-    	// i.e. when a page object extends a custom class which itself extends HtmlElement
-    	for(clazz = clazz.getSuperclass(); 
-    	    ((clazz != null) && (clazz != BasePage.class) && (clazz != HtmlElement.class));
-    		clazz = clazz.getSuperclass()) {
-    		Stream.of(clazz.getDeclaredFields()).
-    		        forEach(f->allFields.add(f));
-    	}
-    	        		
+        Class <? extends Object> clazz = pageObject.getClass();
+        // Get the declared fields from the current class
+        final List<Field> allFields = new ArrayList<Field>(Arrays.asList(clazz.getDeclaredFields()));
+
+        // Get any declared fields from super classes
+        // i.e. when a page object extends a custom class which itself extends HtmlElement
+        for(clazz = clazz.getSuperclass(); 
+            ((clazz != null) && (clazz != BasePage.class) && (clazz != HtmlElement.class));
+            clazz = clazz.getSuperclass()) {
+            Stream.of(clazz.getDeclaredFields()).
+                    forEach(f->allFields.add(f));
+        }
+
         allFields.stream()
                 .filter(this::validateFieldVisibilityAnnotations)
                 .forEach(field ->

--- a/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
+++ b/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
@@ -61,10 +61,10 @@ public final class Visibility {
      */
     public void waitForAnnotatedElementVisibility(Object pageObject) {
 
-        Class <? extends Object> clazz = pageObject.getClass();
+        Class <?> clazz = pageObject.getClass();
 
         // Get the declared fields from the current class
-        final List<Field> allFields = new ArrayList<Field>(Arrays.asList(clazz.getDeclaredFields()));
+        final List<Field> allFields = new ArrayList<>(Arrays.asList(clazz.getDeclaredFields()));
 
         // Get the declared fields from the super class
         final List<Field> superClassFields = getDeclaredFieldsFromSuperClasses(clazz);
@@ -75,15 +75,15 @@ public final class Visibility {
                         invokeWaitFunctionForField(field, pageObject));
     }
 
-    private List<Field> getDeclaredFieldsFromSuperClasses(Class <? extends Object> clazz) {
-        final List<Field> fields = new ArrayList<Field>();
+    private List<Field> getDeclaredFieldsFromSuperClasses(Class <?> clazz) {
+        final List<Field> fields = new ArrayList<>();
 
         // Get any declared fields from super classes
         // i.e. when a page object extends a custom class which itself extends HtmlElement
-        for(clazz = clazz.getSuperclass();
-            ((clazz != null) && (clazz != BasePage.class) && (clazz != HtmlElement.class));
-            clazz = clazz.getSuperclass()) {
-            Stream.of(clazz.getDeclaredFields())
+        for(Class<?> c = clazz.getSuperclass();
+            ((c != null) && (c != BasePage.class) && (c != HtmlElement.class));
+            c = c.getSuperclass()) {
+            Stream.of(c.getDeclaredFields())
                      // Filter out static fields
                     .filter(m->!Modifier.isStatic(m.getModifiers()))
                     .forEach(f->fields.add(f));


### PR DESCRIPTION
This PR is to address the limitation of the @Visible annotation feature when a Page Object extends HtmlElement. 

e.g. 
public class MyPanel extends MyPickerPanel

where

public class MyPickerPanel extends HtmlElement