### PR TITLE
Extend google truth

### DIFF
--- a/src/main/java/com/frameworkium/core/ui/truth/ListWebElementSubject.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/ListWebElementSubject.java
@@ -1,8 +1,6 @@
 package com.frameworkium.core.ui.truth;
 
-import com.google.common.truth.FailureMetadata;
-import com.google.common.truth.IterableSubject;
-import com.google.common.truth.Subject;
+import com.google.common.truth.*;
 import org.apache.commons.lang.StringUtils;
 import org.openqa.selenium.WebElement;
 
@@ -10,7 +8,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public final class ListWebElementSubject extends Subject<ListWebElementSubject, List<? extends WebElement>> {
+public class ListWebElementSubject extends Subject<ListWebElementSubject, List<? extends WebElement>> {
 
     public ListWebElementSubject(FailureMetadata metadata, @Nullable List<? extends WebElement> actual) {
         super(metadata, actual);
@@ -31,11 +29,16 @@ public final class ListWebElementSubject extends Subject<ListWebElementSubject, 
     }
 
     public IterableSubject text() {
-        return check().that(actual().stream().map(WebElement::getText).collect(Collectors.toList()));
+        return check().that(
+                actual().stream()
+                        .map(WebElement::getText)
+                        .collect(Collectors.toList()));
     }
 
     public IterableSubject attribute(String attribute) {
-        return check().that(actual().stream().map(webElement -> webElement.getAttribute(attribute)).collect(Collectors.toList()));
+        return check().that(
+                actual().stream()
+                        .map(webElement -> webElement.getAttribute(attribute))
+                        .collect(Collectors.toList()));
     }
 }
-

--- a/src/main/java/com/frameworkium/core/ui/truth/ListWebElementSubject.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/ListWebElementSubject.java
@@ -1,0 +1,41 @@
+package com.frameworkium.core.ui.truth;
+
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.IterableSubject;
+import com.google.common.truth.Subject;
+import org.apache.commons.lang.StringUtils;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ListWebElementSubject extends Subject<ListWebElementSubject, List<? extends WebElement>> {
+
+    public ListWebElementSubject(FailureMetadata metadata, @Nullable List<? extends WebElement> actual) {
+        super(metadata, actual);
+    }
+
+    public void atLeastOneContains(String text) {
+        if (actual().stream()
+                .noneMatch(actual -> actual.getText().contains(text))) {
+            named("WebElements").fail("at least one contains", text);
+        }
+    }
+
+    public void atLeastOneContainsIgnoringCase(String text) {
+        if (actual().stream()
+                .noneMatch(actual -> StringUtils.containsIgnoreCase(actual.getText(), text))) {
+            named("WebElements").fail("at least one contains, ignoring case", text);
+        }
+    }
+
+    public IterableSubject text() {
+        return check().that(actual().stream().map(WebElement::getText).collect(Collectors.toList()));
+    }
+
+    public IterableSubject attribute(String attribute) {
+        return check().that(actual().stream().map(webElement -> webElement.getAttribute(attribute)).collect(Collectors.toList()));
+    }
+}
+

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementSubject.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementSubject.java
@@ -1,0 +1,42 @@
+package com.frameworkium.core.ui.truth;
+
+
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.StringSubject;
+import com.google.common.truth.Subject;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+
+public final class WebElementSubject extends Subject<WebElementSubject, WebElement> {
+
+    WebElementSubject(FailureMetadata metadata, @Nullable WebElement actual) {
+        super(metadata, actual);
+    }
+
+    public void isDisplayed() {
+        if (!actual().isDisplayed()) {
+            named("WebElement").fail("is displayed");
+        }
+    }
+
+    public void isEnabled() {
+        if (!actual().isEnabled()) {
+            named("WebElement").fail("is enabled");
+        }
+    }
+
+    public void isSelected() {
+        if (!actual().isSelected()) {
+            named("WebElement").fail("is selected");
+        }
+    }
+
+    public StringSubject text() {
+        return check().that(actual().getText());
+    }
+
+    public StringSubject attribute(String attribute) {
+        return check().that(actual().getAttribute(attribute));
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementSubject.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementSubject.java
@@ -1,14 +1,11 @@
 package com.frameworkium.core.ui.truth;
 
-
-import com.google.common.truth.FailureMetadata;
-import com.google.common.truth.StringSubject;
-import com.google.common.truth.Subject;
+import com.google.common.truth.*;
 import org.openqa.selenium.WebElement;
 
 import javax.annotation.Nullable;
 
-public final class WebElementSubject extends Subject<WebElementSubject, WebElement> {
+public class WebElementSubject extends Subject<WebElementSubject, WebElement> {
 
     WebElementSubject(FailureMetadata metadata, @Nullable WebElement actual) {
         super(metadata, actual);

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementSubjectBuilder.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementSubjectBuilder.java
@@ -1,0 +1,26 @@
+package com.frameworkium.core.ui.truth;
+
+import com.google.common.truth.CustomSubjectBuilder;
+import com.google.common.truth.FailureMetadata;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public final class WebElementSubjectBuilder extends CustomSubjectBuilder {
+    private WebElementSubjectBuilder(FailureMetadata metadata) {
+        super(metadata);
+    }
+
+    public final WebElementSubject that(@Nullable WebElement actual) {
+        return new WebElementSubject(metadata(), actual);
+    }
+
+    public final ListWebElementSubject that(@Nullable List<? extends WebElement> actual) {
+        return new ListWebElementSubject(metadata(), actual);
+    }
+
+    public static Factory<WebElementSubjectBuilder> elements() {
+        return WebElementSubjectBuilder::new;
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementSubjectBuilder.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementSubjectBuilder.java
@@ -7,7 +7,8 @@ import org.openqa.selenium.WebElement;
 import javax.annotation.Nullable;
 import java.util.List;
 
-public final class WebElementSubjectBuilder extends CustomSubjectBuilder {
+public class WebElementSubjectBuilder extends CustomSubjectBuilder {
+
     private WebElementSubjectBuilder(FailureMetadata metadata) {
         super(metadata);
     }

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementTruth.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementTruth.java
@@ -1,0 +1,28 @@
+package com.frameworkium.core.ui.truth;
+
+import com.google.common.truth.CustomSubjectBuilder;
+import org.openqa.selenium.WebElement;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.Truth.assert_;
+
+public final class WebElementTruth {
+    private static CustomSubjectBuilder.Factory<WebElementSubjectBuilder> elements() {
+        return WebElementSubjectBuilder.elements();
+    }
+
+    public static WebElementSubject assertThat(@Nullable WebElement actual) {
+        return assertAbout(elements()).that(actual);
+    }
+
+    public static ListWebElementSubject assertThat(@Nullable List<? extends WebElement> actual) {
+        return assertAbout(elements()).that(actual);
+    }
+
+    public static WebElementSubjectBuilder assertWithMessage(String messageToPrepend) {
+        return assert_().withMessage(messageToPrepend).about(elements());
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/truth/WebElementTruth.java
+++ b/src/main/java/com/frameworkium/core/ui/truth/WebElementTruth.java
@@ -9,7 +9,8 @@ import java.util.List;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assert_;
 
-public final class WebElementTruth {
+public class WebElementTruth {
+
     private static CustomSubjectBuilder.Factory<WebElementSubjectBuilder> elements() {
         return WebElementSubjectBuilder.elements();
     }

--- a/src/test/groovy/com/frameworkium/core/ui/truth/WebElementSubjectSpec.groovy
+++ b/src/test/groovy/com/frameworkium/core/ui/truth/WebElementSubjectSpec.groovy
@@ -1,0 +1,28 @@
+package com.frameworkium.core.ui.truth
+
+import org.openqa.selenium.WebElement
+import spock.lang.Specification
+
+class WebElementSubjectSpec extends Specification {
+
+    def "displayed element passes is displayed assertion"() {
+        given:
+            def webElement = Mock(WebElement)
+        when:
+            WebElementTruth.assertThat(webElement).isDisplayed()
+        then:
+            1 * webElement.isDisplayed() >> true
+            noExceptionThrown()
+    }
+
+    def "not displayed element fails is displayed assertion"() {
+        given:
+            def webElement = Mock(WebElement)
+        when:
+            WebElementTruth.assertThat(webElement).isDisplayed()
+        then:
+            1 * webElement.isDisplayed() >> false
+            def error = thrown(AssertionError)
+            error.message == "Not true that WebElement (<Mock for type 'WebElement' named 'webElement'>) is displayed"
+    }
+}

--- a/src/test/groovy/com/frameworkium/core/ui/truth/WebElementSubjectSpec.groovy
+++ b/src/test/groovy/com/frameworkium/core/ui/truth/WebElementSubjectSpec.groovy
@@ -5,7 +5,7 @@ import spock.lang.Specification
 
 class WebElementSubjectSpec extends Specification {
 
-    def "displayed element passes is displayed assertion"() {
+    def "element is displayed, passes isDisplayed() assertion"() {
         given:
             def webElement = Mock(WebElement)
         when:
@@ -15,7 +15,7 @@ class WebElementSubjectSpec extends Specification {
             noExceptionThrown()
     }
 
-    def "not displayed element fails is displayed assertion"() {
+    def "element not displayed, isDisplayed() assertion throws Error"() {
         given:
             def webElement = Mock(WebElement)
         when:
@@ -23,6 +23,6 @@ class WebElementSubjectSpec extends Specification {
         then:
             1 * webElement.isDisplayed() >> false
             def error = thrown(AssertionError)
-            error.message == "Not true that WebElement (<Mock for type 'WebElement' named 'webElement'>) is displayed"
+            error.message ==~ /Not true that WebElement .* is displayed/
     }
 }


### PR DESCRIPTION
* Allows direct assertions on WebElement(s) e.g assertThat(WebElement).isDisplayed()
* Allows WebElement assertions to pipe to String or Iterable Subject assertions e.g. assertThat(WebElement).text().isEqualsTo("String")
