### PR TITLE
Automatic webdrivers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,7 @@
                       <goals>
                           <goal>selenium</goal>
                       </goals>
+		      <phase>none</phase>
                   </execution>
               </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -363,6 +363,35 @@
             </executions>
           </plugin>
 
+          <!-- Used to automatically download web drivers -->
+          <plugin>
+              <groupId>com.lazerycode.selenium</groupId>
+              <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+              <version>1.0.14</version>
+              <configuration>
+                  <!-- root directory that downloaded driver binaries will be stored in -->
+                  <rootStandaloneServerDirectory>drivers/binaries/</rootStandaloneServerDirectory>
+                  <!-- Where you want to store downloaded zip files -->
+                  <downloadedZipFileDirectory>drivers/zip/</downloadedZipFileDirectory>
+
+                  <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                  <thirtyTwoBitBinaries>false</thirtyTwoBitBinaries>
+                  <sixtyFourBitBinaries>true</sixtyFourBitBinaries>
+                  <onlyGetLatestVersions>true</onlyGetLatestVersions>
+
+                  <!-- auto detect system proxy to use when downloading files -->
+                  <!-- To specify an explicit proxy set the environment variables http.proxyHost and http.proxyPort -->
+                  <!-- <useSystemProxy>true</useSystemProxy> -->
+              </configuration>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>selenium</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
+
           <!-- Used to attach sources to jar -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
               <version>1.0.14</version>
               <configuration>
                   <!-- root directory that downloaded driver binaries will be stored in -->
-                  <rootStandaloneServerDirectory>drivers/binaries/</rootStandaloneServerDirectory>
+                  <rootStandaloneServerDirectory>drivers/bin/</rootStandaloneServerDirectory>
                   <!-- Where you want to store downloaded zip files -->
                   <downloadedZipFileDirectory>drivers/zip/</downloadedZipFileDirectory>
 


### PR DESCRIPTION
Only explicitly running "mvn driver-binary-downloader:selenium" will download the drivers.