### PR TITLE
Refactored ScreenshotListener to enable unit testing

### DIFF
--- a/src/main/java/com/frameworkium/core/ui/listeners/ScreenshotListener.java
+++ b/src/main/java/com/frameworkium/core/ui/listeners/ScreenshotListener.java
@@ -2,17 +2,16 @@ package com.frameworkium.core.ui.listeners;
 
 import com.frameworkium.core.ui.capture.ScreenshotCapture;
 import com.frameworkium.core.ui.driver.DriverSetup.Browser;
-import com.frameworkium.core.ui.driver.WebDriverWrapper;
 import com.frameworkium.core.ui.tests.BaseTest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.*;
-import org.openqa.selenium.remote.Augmenter;
 import org.testng.ITestResult;
 import org.testng.TestListenerAdapter;
 import ru.yandex.qatools.allure.annotations.Attachment;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.*;
 
 import static com.frameworkium.core.common.properties.Property.BROWSER;
@@ -21,71 +20,65 @@ import static com.frameworkium.core.ui.driver.DriverSetup.Browser.ELECTRON;
 public class ScreenshotListener extends TestListenerAdapter {
 
     private static final Logger logger = LogManager.getLogger();
+    private final boolean captureEnabled = ScreenshotCapture.isRequired();
 
     @Override
     public void onTestFailure(ITestResult failingTest) {
-        if (isScreenshotSupported()) {
+        if (!captureEnabled && isScreenshotSupported()) {
             takeScreenshotAndSaveLocally(failingTest.getName());
         }
     }
 
     @Override
     public void onTestSkipped(ITestResult skippedTest) {
-        if (isScreenshotSupported()) {
+        if (!captureEnabled && isScreenshotSupported()) {
             takeScreenshotAndSaveLocally(skippedTest.getName());
         }
     }
 
     private void takeScreenshotAndSaveLocally(String testName) {
-        // Take a local screenshot if capture is not enabled
-        if (!ScreenshotCapture.isRequired()) {
-            try {
-                String screenshotDirectory = System.getProperty("screenshotDirectory");
-                if (screenshotDirectory == null) {
-                    screenshotDirectory = "screenshots";
-                }
-                String absolutePath =
-                        screenshotDirectory + File.separator
-                                + System.currentTimeMillis() + "_" + testName + ".png";
-                Path screenshot = Paths.get(absolutePath);
-                if (createScreenshotDirectory(screenshot.getParent())) {
-                    WebDriverWrapper driver = BaseTest.getDriver();
-                    try {
-                        writeScreenshotToFile(driver, screenshot);
-                    } catch (ClassCastException cce) {
-                        // We need to augment our driver object
-                        writeScreenshotToFile(new Augmenter().augment(driver), screenshot);
-                    }
-                    logger.info("Written screenshot to " + absolutePath);
-                } else {
-                    logger.error("Unable to create " + absolutePath);
-                }
-            } catch (Exception e) {
-                logger.error("Unable to take screenshot - " + e);
-            }
+        takeScreenshotAndSaveLocally(testName, BaseTest.getDriver());
+    }
+
+    private void takeScreenshotAndSaveLocally(String testName, TakesScreenshot driver) {
+        String screenshotDirectory = System.getProperty("screenshotDirectory");
+        if (screenshotDirectory == null) {
+            screenshotDirectory = "screenshots";
+        }
+        String fileName = String.format(
+                "%s_%s.png",
+                System.currentTimeMillis(),
+                testName);
+        Path screenshotPath = Paths.get(screenshotDirectory);
+        Path absolutePath = screenshotPath.resolve(fileName);
+        if (createScreenshotDirectory(screenshotPath)) {
+            writeScreenshotToFile(driver, absolutePath);
+            logger.info("Written screenshot to " + absolutePath);
+        } else {
+            logger.error("Unable to create " + screenshotPath);
         }
     }
 
     private boolean createScreenshotDirectory(Path screenshotDirectory) {
-        if (!Files.isDirectory(screenshotDirectory)) {
-            try {
-                Files.createDirectories(screenshotDirectory);
-            } catch (IOException e) {
-                logger.error("Error creating screenshot directory", e);
-            }
+        try {
+            Files.createDirectories(screenshotDirectory);
+        } catch (IOException e) {
+            logger.error("Error creating screenshot directory", e);
         }
         return Files.isDirectory(screenshotDirectory);
     }
 
     @Attachment(value = "Screenshot on failure", type = "image/png")
-    private byte[] writeScreenshotToFile(WebDriver driver, Path screenshot) {
+    private byte[] writeScreenshotToFile(TakesScreenshot driver, Path screenshot) {
         try (OutputStream screenshotStream = Files.newOutputStream(screenshot)) {
-            byte[] bytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+            byte[] bytes = driver.getScreenshotAs(OutputType.BYTES);
             screenshotStream.write(bytes);
             screenshotStream.close();
             return bytes;
         } catch (IOException e) {
             logger.error("Unable to write " + screenshot, e);
+        } catch (WebDriverException e) {
+            logger.error("Unable to take screenshot." + e);
         }
         return null;
     }

--- a/src/test/groovy/com/frameworkium/core/ui/listeners/ScreenshotListenerSpec.groovy
+++ b/src/test/groovy/com/frameworkium/core/ui/listeners/ScreenshotListenerSpec.groovy
@@ -1,0 +1,43 @@
+package com.frameworkium.core.ui.listeners
+
+import org.openqa.selenium.TakesScreenshot
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class ScreenshotListenerSpec extends Specification {
+
+    def testName = "testName"
+    def defaultScreenshotFolder = Paths.get("screenshots")
+
+    def setup() {
+        Files.createDirectories(defaultScreenshotFolder)
+    }
+
+    def cleanup() {
+        listAllTestScreenshots()
+                .map({ it.toFile() })
+                .forEach({ it.delete() })
+    }
+
+    def sut = new ScreenshotListener()
+
+    def "takeScreenshotAndSaveLocally takes a screenshot and saves file"() {
+        given:
+            TakesScreenshot mockDriver = Mock()
+            def screenshotCount = listAllTestScreenshots().count()
+        when:
+            sut.takeScreenshotAndSaveLocally(testName, mockDriver)
+        then:
+            1 * mockDriver.getScreenshotAs(_) >> { [1, 2, 3] as byte[] }
+            listAllTestScreenshots().count() == screenshotCount + 1
+
+    }
+
+    def listAllTestScreenshots() {
+        Files.walk(defaultScreenshotFolder)
+                .filter({ it.toString().endsWith(testName + ".png") })
+    }
+
+}


### PR DESCRIPTION
Refactored for testing and clarity.
This might also fix #44, however, as I've removed the `catch Exception` it might cause other issues, but would be good to get them reported and fixed rather than hidden and logged under "failed to create screenshot".