### PR TITLE
Replaced DesiredCapabilities with Capabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.3</version>
+            <version>8.5</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/src/main/java/com/frameworkium/core/ui/driver/AbstractDriver.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/AbstractDriver.java
@@ -8,10 +8,9 @@ import com.frameworkium.core.ui.listeners.CaptureListener;
 import com.frameworkium.core.ui.listeners.LoggingListener;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.Proxy;
+import org.openqa.selenium.*;
 import org.openqa.selenium.Proxy.ProxyType;
 import org.openqa.selenium.remote.CapabilityType;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -25,10 +24,6 @@ public abstract class AbstractDriver implements Driver {
 
     private WebDriverWrapper webDriverWrapper;
 
-    /**
-     * Clean up code - quit the driver.
-     * {@inheritDoc}
-     */
     @Override
     public void tearDown() {
         if (Property.REUSE_BROWSER.isSpecified()) {
@@ -38,35 +33,32 @@ public abstract class AbstractDriver implements Driver {
         }
     }
 
-    /**
-     * Getter.
-     * {@inheritDoc}
-     **/
     @Override
     public WebDriverWrapper getDriver() {
         return this.webDriverWrapper;
     }
 
-    /** Creates the Wrapped Driver object and maximises if required. */
+    /**
+     * Creates the Wrapped Driver object and maximises if required.
+     */
     public void initialise() {
-        DesiredCapabilities capsFromImpl = getDesiredCapabilities();
-        DesiredCapabilities caps = addProxyIfRequired(capsFromImpl);
-        logger.debug("Browser Capabilities: " + caps);
-
-        this.webDriverWrapper = setupEventFiringWebDriver(caps);
-
+        this.webDriverWrapper = setupEventFiringWebDriver(getCapabilities());
         maximiseBrowserIfRequired();
     }
 
-    private DesiredCapabilities addProxyIfRequired(DesiredCapabilities caps) {
-        Proxy currentProxy = getProxy();
-        if (currentProxy != null) {
-            caps.setCapability(CapabilityType.PROXY, currentProxy);
+    private Capabilities addProxyIfRequired(Capabilities caps) {
+        if (Property.PROXY.isSpecified()) {
+            MutableCapabilities mutableCapabilities = new MutableCapabilities();
+            mutableCapabilities.setCapability(CapabilityType.PROXY, getProxy());
+            return caps.merge(mutableCapabilities);
+        } else {
+            return caps;
         }
-        return caps;
     }
 
-    private WebDriverWrapper setupEventFiringWebDriver(DesiredCapabilities caps) {
+    private WebDriverWrapper setupEventFiringWebDriver(Capabilities capabilities) {
+        Capabilities caps = addProxyIfRequired(capabilities);
+        logger.debug("Browser Capabilities: " + caps);
         WebDriverWrapper eventFiringWD = new WebDriverWrapper(getWebDriver(caps));
         eventFiringWD.register(new LoggingListener());
         if (ScreenshotCapture.isRequired()) {
@@ -78,9 +70,6 @@ public abstract class AbstractDriver implements Driver {
         return eventFiringWD;
     }
 
-    /**
-     * Maximises the browser window based on maximise property.
-     **/
     private void maximiseBrowserIfRequired() {
         if (isMaximiseRequired()) {
             this.webDriverWrapper.manage().window().maximize();
@@ -97,16 +86,11 @@ public abstract class AbstractDriver implements Driver {
 
     /**
      * Get proxy object with settings set by the system properties.
-     * If no valid proxy argument is set then it returns null.
+     * Requires Property.PROXY.isSpecified()
      *
      * @return A Selenium proxy object for the current system properties
-     *         or null if no valid proxy settings.
      */
     private Proxy getProxy() {
-        if (!Property.PROXY.isSpecified()) {
-            return null;
-        }
-
         Proxy proxy = new Proxy();
         String proxyString = Property.PROXY.getValue().toLowerCase();
         switch (proxyString) {
@@ -130,9 +114,12 @@ public abstract class AbstractDriver implements Driver {
                             .setHttpProxy(proxyString)
                             .setFtpProxy(proxyString)
                             .setSslProxy(proxyString);
-                    logger.debug("Set all protocols to use proxy address: " + proxyString);
+                    logger.debug("Set all protocols to use proxy address: {}", proxyString);
                 } catch (URISyntaxException e) {
-                    logger.error("Invalid proxy specified, acceptable values are: system, autodetect, direct or http://{hostname}:{port}.");
+                    String message = "Invalid proxy specified, acceptable values are: " +
+                            "system, autodetect, direct or http://{hostname}:{port}.";
+                    logger.error(message);
+                    throw new IllegalArgumentException(message);
                 }
                 break;
         }

--- a/src/main/java/com/frameworkium/core/ui/driver/AbstractDriver.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/AbstractDriver.java
@@ -116,8 +116,8 @@ public abstract class AbstractDriver implements Driver {
                             .setSslProxy(proxyString);
                     logger.debug("Set all protocols to use proxy address: {}", proxyString);
                 } catch (URISyntaxException e) {
-                    String message = "Invalid proxy specified, acceptable values are: " +
-                            "system, autodetect, direct or http://{hostname}:{port}.";
+                    String message = "Invalid proxy specified, acceptable values are: "
+                            + "system, autodetect, direct or http://{hostname}:{port}.";
                     logger.error(message);
                     throw new IllegalArgumentException(message);
                 }

--- a/src/main/java/com/frameworkium/core/ui/driver/Driver.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/Driver.java
@@ -1,7 +1,7 @@
 package com.frameworkium.core.ui.driver;
 
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import static com.frameworkium.core.common.properties.Property.APP_PATH;
 
@@ -26,17 +26,17 @@ public interface Driver {
     /**
      * Implemented in each Driver Type to specify the capabilities of that browser.
      *
-     * @return Desired Capabilities of each browser
+     * @return Capabilities of each browser
      */
-    DesiredCapabilities getDesiredCapabilities();
+    Capabilities getCapabilities();
 
     /**
-     * Returns the correct WebDriver object for the driver type.
+     * Returns the correct WebDriver object for the Driver Type.
      *
      * @param capabilities Capabilities of the browser
      * @return {@link WebDriver} object for the browser
      */
-    WebDriver getWebDriver(DesiredCapabilities capabilities);
+    WebDriver getWebDriver(Capabilities capabilities);
 
     /**
      * Getter for the driver that wraps the initialised driver.

--- a/src/main/java/com/frameworkium/core/ui/driver/DriverSetup.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/DriverSetup.java
@@ -6,7 +6,7 @@ import com.frameworkium.core.ui.driver.remotes.BrowserStack;
 import com.frameworkium.core.ui.driver.remotes.Sauce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.Capabilities;
 import org.reflections.Reflections;
 
 public class DriverSetup {
@@ -52,15 +52,15 @@ public class DriverSetup {
      */
     private Driver instantiateDesiredRemote(Driver driver) {
 
-        DesiredCapabilities desiredCapabilities = driver.getDesiredCapabilities();
+        Capabilities capabilities = driver.getCapabilities();
         Platform platform = getPlatformType();
         switch (returnRemoteType()) {
             case SAUCE:
-                return new SauceImpl(platform, desiredCapabilities);
+                return new SauceImpl(platform, capabilities);
             case BROWSERSTACK:
-                return new BrowserStackImpl(platform, desiredCapabilities);
+                return new BrowserStackImpl(platform, capabilities);
             case GRID:
-                return new GridImpl(desiredCapabilities);
+                return new GridImpl(capabilities);
             default:
                 return driver;
         }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/BrowserStackImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/BrowserStackImpl.java
@@ -31,6 +31,7 @@ public class BrowserStackImpl extends AbstractDriver {
         }
     }
 
+    /** {@inheritDoc} */
     public Capabilities getCapabilities() {
         MutableCapabilities capabilities = getCapabilitiesBasedOnPlatform();
         capabilities.setCapability("browserstack.debug", true);

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/BrowserStackImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/BrowserStackImpl.java
@@ -3,8 +3,7 @@ package com.frameworkium.core.ui.driver.drivers;
 import com.frameworkium.core.common.properties.Property;
 import com.frameworkium.core.ui.driver.AbstractDriver;
 import com.frameworkium.core.ui.driver.remotes.BrowserStack;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -16,85 +15,80 @@ public class BrowserStackImpl extends AbstractDriver {
 
     private URL remoteURL;
     private Platform platform;
-    private DesiredCapabilities desiredCapabilities;
+    private Capabilities capabilities;
 
     /**
      * Implementation of driver for BrowserStack.
      */
-    public BrowserStackImpl(
-            Platform platform, DesiredCapabilities browserDesiredCapabilities) {
+    public BrowserStackImpl(Platform platform, Capabilities browserCapabilities) {
 
         this.platform = platform;
-        desiredCapabilities = browserDesiredCapabilities;
+        capabilities = browserCapabilities;
         try {
             remoteURL = BrowserStack.getURL();
         } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            throw new IllegalArgumentException(e);
         }
     }
 
-    /**
-     * Get desired capabilities.
-     */
-    public DesiredCapabilities getDesiredCapabilities() {
-        setCapabilitiesBasedOnPlatform();
-        desiredCapabilities.setCapability("browserstack.debug", true);
-        return desiredCapabilities;
+    public Capabilities getCapabilities() {
+        MutableCapabilities capabilities = getCapabilitiesBasedOnPlatform();
+        capabilities.setCapability("browserstack.debug", true);
+        return capabilities;
     }
 
-    /**
-     * Get web driver.
-     *
-     * @param capabilities Capabilities of the browser
-     */
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new RemoteWebDriver(remoteURL, capabilities);
-    }
-
-    private void setCapabilitiesBasedOnPlatform() {
+    private MutableCapabilities getCapabilitiesBasedOnPlatform() {
+        MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
         switch (platform) {
             case WINDOWS:
-                desiredCapabilities.setCapability("os", "Windows");
-                setDesktopCapability();
+                mutableCapabilities.setCapability("os", "Windows");
+                mutableCapabilities.merge(getDesktopCapability());
                 break;
             case OSX:
-                desiredCapabilities.setCapability("os", "OS X");
-                setDesktopCapability();
+                mutableCapabilities.setCapability("os", "OS X");
+                mutableCapabilities.merge(getDesktopCapability());
                 break;
             case ANDROID:
-                desiredCapabilities.setCapability("platform", "ANDROID");
-                desiredCapabilities.setCapability("browserName", "android");
+                mutableCapabilities.setCapability("platform", "ANDROID");
+                mutableCapabilities.setCapability("browserName", "android");
                 if (Property.DEVICE.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "device", Property.DEVICE.getValue());
                 }
                 break;
             case IOS:
-                desiredCapabilities.setCapability("platform", "MAC");
+                mutableCapabilities.setCapability("platform", "MAC");
                 if (Property.DEVICE.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "device", Property.DEVICE.getValue());
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "browserName", Property.DEVICE.getValue().split(" ")[0]);
                 }
                 break;
             default:
                 break;
         }
+        return mutableCapabilities;
     }
 
-    private void setDesktopCapability() {
+    private MutableCapabilities getDesktopCapability() {
+        MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
         if (Property.PLATFORM_VERSION.isSpecified()) {
-            desiredCapabilities.setCapability(
+            mutableCapabilities.setCapability(
                     "os_version", Property.PLATFORM_VERSION.getValue());
         }
         if (Property.RESOLUTION.isSpecified()) {
-            desiredCapabilities.setCapability(
+            mutableCapabilities.setCapability(
                     "resolution", Property.RESOLUTION.getValue());
         }
         if (Property.BROWSER_VERSION.isSpecified()) {
-            desiredCapabilities.setCapability(
+            mutableCapabilities.setCapability(
                     "browser_version", Property.BROWSER_VERSION.getValue());
         }
+        return mutableCapabilities;
+    }
+
+    public WebDriver getWebDriver(Capabilities capabilities) {
+        return new RemoteWebDriver(remoteURL, capabilities);
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
@@ -3,10 +3,10 @@ package com.frameworkium.core.ui.driver.drivers;
 import com.frameworkium.core.common.properties.Property;
 import com.frameworkium.core.ui.driver.AbstractDriver;
 import com.google.common.collect.ImmutableMap;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.Map;
 
@@ -15,8 +15,8 @@ import static java.util.Collections.singletonList;
 public class ChromeImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+    public Capabilities getCapabilities() {
+        ChromeOptions capabilities = new ChromeOptions();
         capabilities.setCapability(
                 "chrome.switches",
                 singletonList("--no-default-browser-check"));
@@ -47,8 +47,8 @@ public class ChromeImpl extends AbstractDriver {
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new ChromeDriver(capabilities);
+    public WebDriver getWebDriver(Capabilities capabilities) {
+        return new ChromeDriver(new ChromeOptions().merge(capabilities));
     }
 
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
@@ -8,42 +8,35 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
-import java.util.Map;
-
 import static java.util.Collections.singletonList;
 
 public class ChromeImpl extends AbstractDriver {
 
     @Override
     public Capabilities getCapabilities() {
-        ChromeOptions capabilities = new ChromeOptions();
-        capabilities.setCapability(
+        ChromeOptions chromeOptions = new ChromeOptions();
+        // useful defaults
+        chromeOptions.setCapability(
                 "chrome.switches",
                 singletonList("--no-default-browser-check"));
-        capabilities.setCapability(
+        chromeOptions.setCapability(
                 "chrome.prefs",
                 ImmutableMap.of("profile.password_manager_enabled", "false"));
 
         // Use Chrome's built in device emulators
-        // Specify browser=chrome, but also provide device name to use chrome's emulator
         if (Property.DEVICE.isSpecified()) {
-            Map<String, Map<String, String>> chromeOptions = ImmutableMap.of(
-                    "mobileEmulation", ImmutableMap.of(
-                            "deviceName", Property.DEVICE.getValue()));
-
-            capabilities.setCapability(ChromeOptions.CAPABILITY, chromeOptions);
+            chromeOptions.setExperimentalOption(
+                    "mobileEmulation",
+                    ImmutableMap.of("deviceName", Property.DEVICE.getValue()));
         }
 
         // Allow user to provide their own user directory, for custom chrome profiles
         if (Property.CHROME_USER_DATA_DIR.isSpecified()) {
-            ChromeOptions options = new ChromeOptions();
-            options.addArguments(
+            chromeOptions.addArguments(
                     "user-data-dir=" + Property.CHROME_USER_DATA_DIR.getValue());
-
-            capabilities.setCapability(ChromeOptions.CAPABILITY, options);
         }
 
-        return capabilities;
+        return chromeOptions;
     }
 
     @Override

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/ElectronImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/ElectronImpl.java
@@ -1,14 +1,13 @@
 package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 import static com.frameworkium.core.common.properties.Property.APP_PATH;
 
@@ -25,22 +24,19 @@ public class ElectronImpl extends AbstractDriver {
     }
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        Map<String, String> chromeOptions = new HashMap<>();
+    public Capabilities getCapabilities() {
         if (!APP_PATH.isSpecified()) {
             throw new IllegalStateException(
                     "App path must be specified when using Electron!");
-        } else {
-            chromeOptions.put("binary", APP_PATH.getValue());
         }
-        DesiredCapabilities desiredCapabilities = DesiredCapabilities.chrome();
-        desiredCapabilities.setCapability("browserName", "chrome");
-        desiredCapabilities.setCapability("chromeOptions", chromeOptions);
-        return desiredCapabilities;
+
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.setBinary(APP_PATH.getValue());
+        return chromeOptions;
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new RemoteWebDriver(remoteURL, capabilities);
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/FirefoxImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/FirefoxImpl.java
@@ -1,20 +1,20 @@
 package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class FirefoxImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        return DesiredCapabilities.firefox();
+    public Capabilities getCapabilities() {
+        return new FirefoxOptions();
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new FirefoxDriver(new FirefoxOptions().merge(capabilities));
+    public WebDriver getWebDriver(Capabilities capabilities) {
+        return new FirefoxDriver(new FirefoxOptions(capabilities));
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
@@ -2,8 +2,7 @@ package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.common.properties.Property;
 import com.frameworkium.core.ui.driver.AbstractDriver;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.*;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.net.MalformedURLException;
@@ -14,13 +13,13 @@ import static com.frameworkium.core.common.properties.Property.*;
 public class GridImpl extends AbstractDriver {
 
     private URL remoteURL;
-    private DesiredCapabilities desiredCapabilities;
+    private Capabilities capabilities;
 
     /**
      * Implementation of driver for the Selenium Grid .
      */
-    public GridImpl(DesiredCapabilities desiredCapabilities) {
-        this.desiredCapabilities = desiredCapabilities;
+    public GridImpl(Capabilities capabilities) {
+        this.capabilities = capabilities;
         try {
             this.remoteURL = new URL(Property.GRID_URL.getValue());
         } catch (MalformedURLException e) {
@@ -28,23 +27,21 @@ public class GridImpl extends AbstractDriver {
         }
     }
 
-    /**
-     * Get desired capabilities.
-     */
-    public DesiredCapabilities getDesiredCapabilities() {
+    public Capabilities getCapabilities() {
+        MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
         if (BROWSER_VERSION.isSpecified()) {
-            desiredCapabilities.setCapability("version", BROWSER_VERSION.getValue());
+            mutableCapabilities.setCapability("version", BROWSER_VERSION.getValue());
         }
         if (PLATFORM.isSpecified()) {
-            desiredCapabilities.setCapability("platform", PLATFORM_VERSION.getValue());
+            mutableCapabilities.setCapability("platform", PLATFORM_VERSION.getValue());
         }
         if (APPLICATION_NAME.isSpecified()) {
-            desiredCapabilities.setCapability("applicationName", APPLICATION_NAME.getValue());
+            mutableCapabilities.setCapability("applicationName", APPLICATION_NAME.getValue());
         }
-        return desiredCapabilities;
+        return mutableCapabilities;
     }
 
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new RemoteWebDriver(remoteURL, capabilities);
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/GridImpl.java
@@ -27,6 +27,7 @@ public class GridImpl extends AbstractDriver {
         }
     }
 
+    /** {@inheritDoc} */
     public Capabilities getCapabilities() {
         MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
         if (BROWSER_VERSION.isSpecified()) {

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/InternetExplorerImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/InternetExplorerImpl.java
@@ -1,24 +1,25 @@
 package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.CapabilityType;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
 public class InternetExplorerImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        DesiredCapabilities capabilities = DesiredCapabilities.internetExplorer();
-        capabilities.setCapability(CapabilityType.ForSeleniumServer.ENSURING_CLEAN_SESSION, true);
-        capabilities.setCapability(InternetExplorerDriver.ENABLE_PERSISTENT_HOVERING, true);
-        capabilities.setCapability("requireWindowFocus", true);
-        return capabilities;
+    public Capabilities getCapabilities() {
+        InternetExplorerOptions ieOptions = new InternetExplorerOptions();
+        ieOptions.setCapability(CapabilityType.ForSeleniumServer.ENSURING_CLEAN_SESSION, true);
+        ieOptions.setCapability(InternetExplorerDriver.ENABLE_PERSISTENT_HOVERING, true);
+        ieOptions.setCapability("requireWindowFocus", true);
+        return ieOptions;
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new InternetExplorerDriver(capabilities);
+    public WebDriver getWebDriver(Capabilities capabilities) {
+        return new InternetExplorerDriver(new InternetExplorerOptions(capabilities));
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/LegacyFirefoxImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/LegacyFirefoxImpl.java
@@ -1,23 +1,14 @@
 package com.frameworkium.core.ui.driver.drivers;
 
-import com.frameworkium.core.ui.driver.AbstractDriver;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 
-public class LegacyFirefoxImpl extends AbstractDriver {
-
-    @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        final DesiredCapabilities capabilities = DesiredCapabilities.firefox();
-        // required for legacy firefox
-        capabilities.setCapability("marionette", false);
-        return capabilities;
-    }
+public class LegacyFirefoxImpl extends FirefoxImpl {
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new FirefoxDriver(new FirefoxOptions().merge(capabilities));
+    public Capabilities getCapabilities() {
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        firefoxOptions.setLegacy(true);
+        return firefoxOptions;
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/OperaImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/OperaImpl.java
@@ -1,6 +1,7 @@
 package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -16,14 +17,14 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 public class OperaImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
+    public Capabilities getCapabilities() {
         DesiredCapabilities capabilities = DesiredCapabilities.opera();
         capabilities.setCapability("opera.arguments", "-nowin -nomail");
         return capabilities;
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new OperaDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/PhantomJSImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/PhantomJSImpl.java
@@ -1,6 +1,7 @@
 package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriver;
 import org.openqa.selenium.phantomjs.PhantomJSDriverService;
@@ -13,7 +14,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 public class PhantomJSImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
+    public Capabilities getCapabilities() {
         DesiredCapabilities capabilities = DesiredCapabilities.phantomjs();
         capabilities.setCapability("takesScreenshot", true);
         capabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS,
@@ -22,7 +23,7 @@ public class PhantomJSImpl extends AbstractDriver {
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new PhantomJSDriver(capabilities);
     }
 

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/SafariImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/SafariImpl.java
@@ -2,30 +2,31 @@ package com.frameworkium.core.ui.driver.drivers;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
 import com.frameworkium.core.ui.driver.Driver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
 
 public class SafariImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
+    public Capabilities getCapabilities() {
         if (Driver.isMobile()) {
-            return new DesiredCapabilities();
+            return new SafariOptions();
         } else {
-            DesiredCapabilities capabilities = DesiredCapabilities.safari();
-            capabilities.setCapability("safari.cleanSession", true);
-            return capabilities;
+            SafariOptions safariOptions = new SafariOptions();
+            safariOptions.setCapability("safari.cleanSession", true);
+            return safariOptions;
         }
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         if (Driver.isMobile()) {
             throw new IllegalArgumentException(
                     "seleniumGridURL or sauceUser and sauceKey must be specified when running on iOS");
         } else {
-            return new SafariDriver(capabilities);
+            return new SafariDriver(new SafariOptions(capabilities));
         }
     }
 

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/SauceImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/SauceImpl.java
@@ -3,7 +3,7 @@ package com.frameworkium.core.ui.driver.drivers;
 import com.frameworkium.core.ui.driver.AbstractDriver;
 import com.frameworkium.core.ui.driver.Driver;
 import com.frameworkium.core.ui.driver.remotes.Sauce;
-import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.*;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
@@ -18,14 +18,14 @@ public class SauceImpl extends AbstractDriver {
 
     private URL remoteURL;
     private Platform platform;
-    private DesiredCapabilities desiredCapabilities;
+    private Capabilities capabilities;
 
     /**
      * Implementation of driver for SauceLbs.
      */
-    public SauceImpl(Platform platform, DesiredCapabilities desiredCapabilities) {
+    public SauceImpl(Platform platform, Capabilities capabilities) {
         this.platform = platform;
-        this.desiredCapabilities = desiredCapabilities;
+        this.capabilities = capabilities;
         try {
             this.remoteURL = Sauce.getURL();
         } catch (MalformedURLException e) {
@@ -33,113 +33,115 @@ public class SauceImpl extends AbstractDriver {
         }
     }
 
-    /**
-     * Get desired capabilities.
-     */
-    public DesiredCapabilities getDesiredCapabilities() {
+    public Capabilities getCapabilities() {
+        MutableCapabilities mutableCapabilities;
         if (Driver.isNative()) {
-            setAppiumCapabilities();
+            mutableCapabilities = getAppiumCapabilities();
         } else {
-            setCapabilitiesBasedOnPlatform();
+            mutableCapabilities = getCapabilitiesBasedOnPlatform();
         }
-        desiredCapabilities.setCapability("capture-html", true);
-        desiredCapabilities.setCapability("sauce-advisor", false);
-        desiredCapabilities.setCapability("build", BUILD.getValue());
-        return desiredCapabilities;
+        mutableCapabilities.setCapability("capture-html", true);
+        mutableCapabilities.setCapability("sauce-advisor", false);
+        mutableCapabilities.setCapability("build", BUILD.getValue());
+        return mutableCapabilities;
     }
 
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new RemoteWebDriver(remoteURL, capabilities);
     }
 
-    private void setCapabilitiesBasedOnPlatform() {
+    private MutableCapabilities getCapabilitiesBasedOnPlatform() {
+        MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
         switch (platform) {
             case WINDOWS:
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "platform", "Windows " + PLATFORM_VERSION.getValue());
                 } else {
                     logger.error("Platform version needs to be specified when using Windows & SauceLabs!");
                 }
                 if (BROWSER_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "version", BROWSER_VERSION.getValue());
                 }
                 break;
             case OSX:
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "platform", "OS X " + PLATFORM_VERSION.getValue());
                 } else {
                     logger.error("Platform version needs to be specified when using OSX & SauceLabs!");
                 }
                 if (BROWSER_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "version", BROWSER_VERSION.getValue());
                 }
                 break;
             case ANDROID:
-                desiredCapabilities = DesiredCapabilities.android();
-                desiredCapabilities.setCapability("platform", "Linux");
+                mutableCapabilities = DesiredCapabilities.android();
+                mutableCapabilities.setCapability("platform", "Linux");
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "version", PLATFORM_VERSION.getValue());
                 }
-                desiredCapabilities.setCapability("deviceName", "Android Emulator");
-                desiredCapabilities.setCapability("deviceOrientation", "portrait");
+                mutableCapabilities.setCapability("deviceName", "Android Emulator");
+                mutableCapabilities.setCapability("deviceOrientation", "portrait");
                 break;
             case IOS:
-                desiredCapabilities = DesiredCapabilities.iphone();
-                desiredCapabilities.setCapability("platform", "OS X 10.10");
+                mutableCapabilities = DesiredCapabilities.iphone();
+                mutableCapabilities.setCapability("platform", "OS X 10.10");
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "version", PLATFORM_VERSION.getValue());
                 }
                 if (DEVICE.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "deviceName", DEVICE.getValue() + " Simulator");
                 }
-                desiredCapabilities.setCapability("deviceOrientation", "portrait");
+                mutableCapabilities.setCapability("deviceOrientation", "portrait");
                 break;
             default:
                 throw new IllegalStateException("Unrecognised platform" + platform);
         }
+        return mutableCapabilities;
     }
 
-    private void setAppiumCapabilities() {
-        desiredCapabilities.setCapability(
+    private MutableCapabilities getAppiumCapabilities() {
+        MutableCapabilities mutableCapabilities = new MutableCapabilities(capabilities);
+        mutableCapabilities.setCapability(
                 "app", "sauce-storage:" + new File(APP_PATH.getValue()).getName());
-        desiredCapabilities.setCapability("appiumVersion", "1.4.10");
-        desiredCapabilities.setCapability("deviceOrientation", "portrait");
+        mutableCapabilities.setCapability("appiumVersion", "1.4.10");
+        mutableCapabilities.setCapability("deviceOrientation", "portrait");
         switch (platform) {
             case IOS:
-                desiredCapabilities = DesiredCapabilities.iphone();
+                mutableCapabilities = DesiredCapabilities.iphone();
                 if (DEVICE.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "deviceName", DEVICE.getValue() + " Simulator");
                 }
-                desiredCapabilities.setCapability("platformName", "iOS");
-                desiredCapabilities.setCapability("browserName", "");
+                mutableCapabilities.setCapability("platformName", "iOS");
+                mutableCapabilities.setCapability("browserName", "");
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "platformVersion", PLATFORM_VERSION.getValue());
                 }
                 break;
             case ANDROID:
-                desiredCapabilities = DesiredCapabilities.android();
+                mutableCapabilities = DesiredCapabilities.android();
                 if (DEVICE.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "deviceName", DEVICE.getValue() + " Emulator");
                 }
-                desiredCapabilities.setCapability("platformName", "Android");
-                desiredCapabilities.setCapability("browserName", "");
+                mutableCapabilities.setCapability("platformName", "Android");
+                mutableCapabilities.setCapability("browserName", "");
                 if (PLATFORM_VERSION.isSpecified()) {
-                    desiredCapabilities.setCapability(
+                    mutableCapabilities.setCapability(
                             "platformVersion", PLATFORM_VERSION.getValue());
                 }
                 break;
             default:
                 throw new IllegalStateException("Appium is only available on iOS/Android");
         }
+        return mutableCapabilities;
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/SauceImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/SauceImpl.java
@@ -33,6 +33,7 @@ public class SauceImpl extends AbstractDriver {
         }
     }
 
+    /** {@inheritDoc} */
     public Capabilities getCapabilities() {
         MutableCapabilities mutableCapabilities;
         if (Driver.isNative()) {

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/WinAppDriverImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/WinAppDriverImpl.java
@@ -5,8 +5,7 @@ import io.appium.java_client.windows.WindowsDriver;
 import io.appium.java_client.windows.WindowsElement;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.*;
 
 import static com.frameworkium.core.common.properties.Property.*;
 
@@ -15,34 +14,36 @@ public class WinAppDriverImpl extends AbstractDriver {
     protected static final Logger logger = LogManager.getLogger();
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        logger.info("Creating desired capabilities for WinAppDriverImpl");
-        final DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
-        desiredCapabilities.setCapability("platformName", "Windows");
+    public Capabilities getCapabilities() {
+        logger.info("Creating capabilities for WinAppDriverImpl");
+        MutableCapabilities mutableCapabilities = new MutableCapabilities();
+        mutableCapabilities.setCapability("platformName", "Windows");
         if (PLATFORM_VERSION.isSpecified()) {
-            desiredCapabilities.setCapability(
+            mutableCapabilities.setCapability(
                     "platform", "Windows " + PLATFORM_VERSION.getValue());
-            desiredCapabilities.setCapability(
+            mutableCapabilities.setCapability(
                     "platformVersion", PLATFORM_VERSION.getValue());
         } else {
-            logger.error("Platform version needs to be specified when using Windows!");
+            String message = "Platform version needs to be specified when using Windows";
+            logger.error(message);
+            throw new IllegalArgumentException(message);
         }
         if (DEVICE.isSpecified()) {
-            desiredCapabilities.setCapability("deviceName", DEVICE.getValue());
+            mutableCapabilities.setCapability("deviceName", DEVICE.getValue());
         } else {
-            desiredCapabilities.setCapability("deviceName", "WindowsPC");
+            mutableCapabilities.setCapability("deviceName", "WindowsPC");
         }
         if (APP_PATH.isSpecified()) {
-            desiredCapabilities.setCapability("app", APP_PATH.getValue());
+            mutableCapabilities.setCapability("app", APP_PATH.getValue());
         } else {
-            desiredCapabilities.setCapability("app", "Root");
+            mutableCapabilities.setCapability("app", "Root");
         }
 
-        return desiredCapabilities;
+        return mutableCapabilities;
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
+    public WebDriver getWebDriver(Capabilities capabilities) {
         return new WindowsDriver<WindowsElement>(capabilities);
     }
 

--- a/src/test/java/com/frameworkium/integration/CustomFirefoxImpl.java
+++ b/src/test/java/com/frameworkium/integration/CustomFirefoxImpl.java
@@ -1,20 +1,24 @@
 package com.frameworkium.integration;
 
 import com.frameworkium.core.ui.driver.AbstractDriver;
+import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 
+/**
+ * Used as a test of CustomImpl functionality
+ */
 public class CustomFirefoxImpl extends AbstractDriver {
 
     @Override
-    public DesiredCapabilities getDesiredCapabilities() {
-        return DesiredCapabilities.firefox();
+    public Capabilities getCapabilities() {
+        return new FirefoxOptions();
     }
 
     @Override
-    public WebDriver getWebDriver(DesiredCapabilities capabilities) {
-        return new FirefoxDriver(capabilities);
+    public WebDriver getWebDriver(Capabilities capabilities) {
+        return new FirefoxDriver(new FirefoxOptions(capabilities));
     }
 
 }


### PR DESCRIPTION
* Removed `DesiredCapabilities` from `Driver` interface, replaced with `Capabilities`
* Changed method names in `Driver` interface to reflect change in return type
* Used `XyzOptions` e.g. `FirefoxOptions` rather than pure `Capabilities`
* Upgraded checkstyle from 8.3 to 8.5