### PR TITLE
Removed chromeUserDataDir option

### DIFF
--- a/src/main/java/com/frameworkium/core/common/properties/Property.java
+++ b/src/main/java/com/frameworkium/core/common/properties/Property.java
@@ -39,7 +39,6 @@ public enum Property {
     MAXIMISE("maximise"),
     RESOLUTION("resolution"),
     VIDEO_CAPTURE_URL("videoCaptureUrl"),
-    CHROME_USER_DATA_DIR("chromeUserDataDir"),
     CUSTOM_BROWSER_IMPL("customBrowserImpl"),
     REUSE_BROWSER("reuseBrowser"),
     THREADS("threads"),

--- a/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/drivers/ChromeImpl.java
@@ -34,11 +34,6 @@ public class ChromeImpl extends AbstractDriver {
                     ImmutableMap.of("deviceName", Property.DEVICE.getValue()));
         }
 
-        // Allow user to provide their own user directory, for custom chrome profiles
-        if (Property.CHROME_USER_DATA_DIR.isSpecified()) {
-            chromeOptions.addArguments(
-                    "user-data-dir=" + Property.CHROME_USER_DATA_DIR.getValue());
-        }
         chromeOptions.setHeadless(Property.HEADLESS.getBoolean());
         return chromeOptions;
     }

--- a/src/main/resources/Empty.yaml
+++ b/src/main/resources/Empty.yaml
@@ -5,7 +5,6 @@ browserStack:
 browserVersion:
 build:
 captureURL:
-chromeUserDataDir:
 customBrowserImpl:
 device:
 gridURL:


### PR DESCRIPTION
Can be added by creating a `customBrowserImpl`, extending `ChromeImpl`, and adding to `getCapabilities`
`chromeOptions.addArguments("user-data-dir=" + path);`