### PR TITLE
Removed reflection library, CustomBrowserImpl now requires full class name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
   - mvn verify -B -Dthreads=${THREAD_COUNT} -Dbrowser=chrome -DreuseBrowser=true -Dheadless=true -DgridURL=http://localhost:4444/wd/hub -DcaptureURL=${CAPTURE_URL} -DsutName="${SUT_NAME}" -DsutVersion="${SUT_VERSION}"
 
   # Custom Browser Impl (without Capture so the PageFactorySpec runs)
-  - mvn verify -B -Dthreads=${THREAD_COUNT} -DcustomBrowserImpl=CustomFirefoxImpl -Dmaximise=true -Dit.test=DocumentationTest 2> /dev/null
+  - mvn verify -B -Dthreads=${THREAD_COUNT} -DcustomBrowserImpl=com.frameworkium.integration.CustomFirefoxImpl -Dmaximise=true -Dit.test=DocumentationTest 2> /dev/null
 
   # Query Jira for which test to run and then log results to Jira
   # Disabled until we have a JIRA to use

--- a/pom.xml
+++ b/pom.xml
@@ -206,13 +206,6 @@
       <artifactId>cucumber-testng</artifactId>
       <version>1.2.5</version>
     </dependency>
-
-    <!-- Used for custom driver implementation lookup -->
-    <dependency>
-      <groupId>org.reflections</groupId>
-      <artifactId>reflections</artifactId>
-      <version>0.9.11</version>
-    </dependency>
   </dependencies>
 
   <repositories />

--- a/src/main/java/com/frameworkium/core/ui/driver/DriverSetup.java
+++ b/src/main/java/com/frameworkium/core/ui/driver/DriverSetup.java
@@ -7,7 +7,6 @@ import com.frameworkium.core.ui.driver.remotes.Sauce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.Capabilities;
-import org.reflections.Reflections;
 
 import java.lang.reflect.InvocationTargetException;
 
@@ -131,19 +130,26 @@ public class DriverSetup {
     }
 
     /**
-     * Returns custom AbstractDriver implementation based on class simple name.
-     * Uses reflections library to find options and chooses the first found.
+     * Returns custom Driver implementation based on (full) class name.
      *
-     * @param implClassName the name of custom browser impl class (SimpleName, not full path)
-     * @return Class implementing AbstractDriver interface
+     * @param implClassName fully qualified name of custom browser impl class
+     * @return Class implementing the Driver interface
      */
-    private static Class<? extends AbstractDriver> getCustomBrowserImpl(String implClassName) {
-        return new Reflections("")
-                .getSubTypesOf(AbstractDriver.class)
-                .stream()
-                .filter(s -> s.getSimpleName().equals(implClassName))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "Problem loading custom browser implementation: " + implClassName));
+    private Class<? extends Driver> getCustomBrowserImpl(String implClassName) {
+        try {
+            return Class.forName(implClassName).asSubclass(Driver.class);
+        } catch (ClassNotFoundException ex) {
+            String message = "Failed to find custom browser implementation class: " + implClassName;
+            logger.fatal(message, ex);
+            throw new IllegalArgumentException(message
+                    + "\nFully qualified class name is required. "
+                    + "e.g. com.frameworkium.ui.MyCustomImpl");
+        } catch (ClassCastException ex) {
+            String message = String.format(
+                    "Custom browser implementation class '%s' does not implement the Driver interface.",
+                    implClassName);
+            logger.fatal(message, ex);
+            throw new IllegalArgumentException(message, ex);
+        }
     }
 }

--- a/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
+++ b/src/main/java/com/frameworkium/core/ui/pages/Visibility.java
@@ -4,13 +4,13 @@ import com.frameworkium.core.ui.ExtraExpectedConditions;
 import com.frameworkium.core.ui.annotations.*;
 import com.frameworkium.core.ui.driver.WebDriverWrapper;
 import com.frameworkium.core.ui.tests.BaseUITest;
-import javassist.Modifier;
 import org.openqa.selenium.*;
 import org.openqa.selenium.support.ui.Wait;
 import ru.yandex.qatools.htmlelements.element.HtmlElement;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;


### PR DESCRIPTION
`-DcustomBrowserImpl` now needs the fully qualified class name, instead of just the class name.

e.g. `-DcustomBrowserImpl=com.frameworkium.CustomFirefoxImpl` instead of just `-DcustomBrowserImpl=CustomFirefoxImpl`