### PR TITLE
Add polymer litelement2 shadowDOM support

### DIFF
--- a/src/main/java/com/frameworkium/core/ui/litelements/element/LitElement.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/element/LitElement.java
@@ -1,0 +1,6 @@
+package com.frameworkium.core.ui.litelements.element;
+
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+
+public class LitElement extends HtmlElement {
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/LitElementLoader.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/LitElementLoader.java
@@ -1,0 +1,342 @@
+package com.frameworkium.core.ui.litelements.loader;
+
+import com.frameworkium.core.ui.litelements.element.LitElement;
+import com.frameworkium.core.ui.litelements.loader.decorator.LitElementDecorator;
+import com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers.LitElementNamedProxyHandler;
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+import ru.yandex.qatools.htmlelements.element.TypifiedElement;
+import ru.yandex.qatools.htmlelements.exceptions.HtmlElementsException;
+import ru.yandex.qatools.htmlelements.loader.HtmlElementLoader;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementLocatorFactory;
+import ru.yandex.qatools.htmlelements.loader.decorator.proxyhandlers.WebElementNamedProxyHandler;
+import ru.yandex.qatools.htmlelements.pagefactory.CustomElementLocatorFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+
+import static com.frameworkium.core.ui.litelements.utils.LitElementUtils.isLitElement;
+import static ru.yandex.qatools.htmlelements.loader.decorator.ProxyFactory.createWebElementProxy;
+import static ru.yandex.qatools.htmlelements.utils.HtmlElementUtils.*;
+
+public class LitElementLoader extends HtmlElementLoader {
+
+    /**
+     * Creates and initializes a block of elements if the given class is {@link HtmlElement},{@link LitElement}
+     * or its successor and initializes page object otherwise.
+     *
+     * @param clazz  A class to be instantiated and initialized.
+     * @param driver The {@code WebDriver} instance that will be used to look up the elements.
+     * @return Initialized instance of the specified class.
+     * @see #createLitElement(Class, SearchContext)
+     * @see #createHtmlElement(Class, SearchContext)
+     * @see #createPageObject(Class, WebDriver)
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T create(Class<T> clazz, WebDriver driver) {
+        if (isLitElement(clazz)) {
+            return (T) createLitElement((Class<LitElement>) clazz, driver);
+        }
+        if (isHtmlElement(clazz)) {
+            return (T) createHtmlElement((Class<HtmlElement>) clazz, driver);
+        }
+        if (isTypifiedElement(clazz)) {
+            return (T) createTypifiedElement((Class<TypifiedElement>) clazz, driver);
+        }
+        return createPageObject(clazz, driver);
+    }
+
+    /**
+     * Initializes {@code instance} as a block of elements it is instance of {@link HtmlElement},{@link LitElement}
+     * or its successor and as a page object otherwise.
+     *
+     * @param instance Object to be initialized.
+     * @param driver   The {@code WebDriver} instance that will be used to look up the elements.
+     * @see #populateLitElement(LitElement, SearchContext)
+     * @see #populateHtmlElement(HtmlElement, SearchContext)
+     * @see #createPageObject(Class, WebDriver)
+     */
+    public static <T> void populate(T instance, WebDriver driver) {
+
+        if (isLitElement(instance)) {
+            populateLitElement((LitElement) instance, driver);
+        } else if (isHtmlElement(instance)) {
+            populateHtmlElement((HtmlElement) instance, driver);
+        } else {
+            // Otherwise consider instance as a page object
+            populatePageObject(instance, driver);
+        }
+    }
+
+    /**
+     * Creates an instance of the given class representing a block of elements and initializes its fields
+     * with lazy proxies.
+     * <p/>
+     * Processes annotation of the given class
+     * to set the way of locating the block itself and {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll}
+     * annotations of its fields for setting the way of locating elements of the block.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     * <li>List of {@code WebElements}</li>     *
+     * <li>Block of elements ({@link HtmlElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param clazz         A class to be instantiated and initialized.
+     * @param searchContext {@code SearchContext} that will be used to look up the elements.
+     * @return Initialized instance of the specified class.
+     */
+    public static <T extends HtmlElement> T createHtmlElement(Class<T> clazz, SearchContext searchContext) {
+        ElementLocator locator = new HtmlElementLocatorFactory(searchContext).createLocator(clazz);
+        String elementName = getElementName(clazz);
+
+        InvocationHandler handler = new WebElementNamedProxyHandler(locator, elementName);
+        WebElement elementToWrap = createWebElementProxy(clazz.getClassLoader(), handler);
+        return createHtmlElement(clazz, elementToWrap, elementName);
+    }
+
+    /**
+     * Creates {@code HtmlElement} instance and recursive populate page objects within it
+     */
+    public static <T extends HtmlElement> T createHtmlElement(Class<T> elementClass, WebElement elementToWrap,
+                                                              String name) {
+        try {
+            T instance = newInstance(elementClass);
+            instance.setWrappedElement(elementToWrap);
+            instance.setName(name);
+            // Recursively initialize elements of the block
+            populatePageObject(instance, elementToWrap);
+            return instance;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                | InvocationTargetException e) {
+            throw new HtmlElementsException(e);
+        }
+    }
+
+    /**
+     * Creates an instance of the given class representing a block of elements and initializes its fields
+     * with lazy proxies.
+     * <p/>
+     * Processes annotation of the given class
+     * to set the way of locating the block itself and {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll}
+     * annotations of its fields for setting the way of locating elements of the block.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     * <li>List of {@code WebElements}</li>
+     * <li>Block of elements ({@link LitElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param clazz         A class to be instantiated and initialized.
+     * @param searchContext {@code SearchContext} that will be used to look up the elements.
+     * @return Initialized instance of the specified class.
+     */
+    public static <T extends LitElement> T createLitElement(Class<T> clazz, SearchContext searchContext) {
+        ElementLocator locator = new HtmlElementLocatorFactory(searchContext).createLocator(clazz);
+        String elementName = getElementName(clazz);
+
+        InvocationHandler handler = new LitElementNamedProxyHandler(locator, elementName);
+        WebElement elementToWrap = createWebElementProxy(clazz.getClassLoader(), handler);
+        return createLitElement(clazz, elementToWrap, elementName);
+    }
+
+    /**
+     * Creates {@code LitElement} instance and recursive populate page objects within it
+     */
+    public static <T extends LitElement> T createLitElement(Class<T> elementClass, WebElement elementToWrap,
+                                                            String name) {
+        try {
+            T instance = newInstance(elementClass);
+            instance.setWrappedElement(elementToWrap);
+            instance.setName(name);
+            // Recursively initialize elements of the block
+            populatePageObject(instance, elementToWrap);
+            return instance;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                | InvocationTargetException e) {
+            throw new HtmlElementsException(e);
+        }
+    }
+
+    /**
+     * Creates an instance of the given page object class and initializes its fields with lazy proxies.
+     * <p/>
+     * Processes {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll}
+     * annotations of the fields for setting the way of locating them.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     *
+     * <li>List of {@code WebElements}</li>
+     * <li>Block of elements ({@link LitElement} and its successors)</li>
+     * <li>Block of elements ({@link HtmlElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param clazz  A class to be instantiated and initialized.
+     * @param driver The {@code WebDriver} instance that will be used to look up the elements.
+     * @return Initialized instance of the specified class.
+     */
+    public static <T> T createPageObject(Class<T> clazz, WebDriver driver) {
+        try {
+            T instance = newInstance(clazz, driver);
+            populatePageObject(instance, driver);
+            return instance;
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+                | InvocationTargetException e) {
+            throw new HtmlElementsException(e);
+        }
+    }
+
+    /**
+     * Initializes fields of the given block of elements with lazy proxies.
+     * <p/>
+     * Processes annotation of the class
+     * of the given block to set the way of locating the block itself and {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll} annotations of its
+     * fields for setting the way of locating elements of the block.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     * <li>List of {@code WebElements}</li>     *
+     * <li>Block of elements ({@link HtmlElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param htmlElement   Block of elements to be initialized.
+     * @param searchContext {@code SearchContext} that will be used to look up the elements.
+     */
+    public static void populateHtmlElement(HtmlElement htmlElement, SearchContext searchContext) {
+        populateHtmlElement(htmlElement, new HtmlElementLocatorFactory(searchContext));
+    }
+
+    /**
+     * Initializes fields of the given block of elements using specified locator factory.
+     *
+     * @param htmlElement    Block of elements to be initialized.
+     * @param locatorFactory Locator factory that will be used to locate block elements.
+     */
+    public static void populateHtmlElement(HtmlElement htmlElement, CustomElementLocatorFactory locatorFactory) {
+        @SuppressWarnings("unchecked")
+        Class<HtmlElement> elementClass = (Class<HtmlElement>) htmlElement.getClass();
+        // Create locator that will handle Block annotation
+        ElementLocator locator = locatorFactory.createLocator(elementClass);
+        ClassLoader elementClassLoader = htmlElement.getClass().getClassLoader();
+        // Initialize block with WebElement proxy and set its name
+        String elementName = getElementName(elementClass);
+        InvocationHandler handler = new WebElementNamedProxyHandler(locator, elementName);
+        WebElement elementToWrap = createWebElementProxy(elementClassLoader, handler);
+        htmlElement.setWrappedElement(elementToWrap);
+        htmlElement.setName(elementName);
+        // Initialize elements of the block
+        populatePageObject(htmlElement, elementToWrap);
+    }
+
+    /**
+     * Initializes fields of the given block of elements with lazy proxies.
+     * <p/>
+     * Processes annotation of the class
+     * of the given block to set the way of locating the block itself and {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll} annotations of its
+     * fields for setting the way of locating elements of the block.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     * <li>List of {@code WebElements}</li>
+     * <li>Block of elements ({@link LitElement} and its successors)</li>
+     * <li>Block of elements ({@link HtmlElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param litElement    Block of elements to be initialized.
+     * @param searchContext {@code SearchContext} that will be used to look up the elements.
+     */
+    public static void populateLitElement(LitElement litElement, SearchContext searchContext) {
+        populateLitElement(litElement, new HtmlElementLocatorFactory(searchContext));
+    }
+
+    /**
+     * Initializes fields of the given block of elements using specified locator factory.
+     *
+     * @param litelement     Block of elements to be initialized.
+     * @param locatorFactory Locator factory that will be used to locate block elements.
+     */
+    public static void populateLitElement(LitElement litelement, CustomElementLocatorFactory locatorFactory) {
+        @SuppressWarnings("unchecked")
+        Class<LitElement> elementClass = (Class<LitElement>) litelement.getClass();
+        // Create locator that will handle Block annotation
+        ElementLocator locator = locatorFactory.createLocator(elementClass);
+        ClassLoader elementClassLoader = litelement.getClass().getClassLoader();
+        // Initialize block with WebElement proxy and set its name
+        String elementName = getElementName(elementClass);
+        InvocationHandler handler = new LitElementNamedProxyHandler(locator, elementName);
+        WebElement elementToWrap = createWebElementProxy(elementClassLoader, handler);
+        litelement.setWrappedElement(elementToWrap);
+        litelement.setName(elementName);
+        // Initialize elements of the block
+        populatePageObject(litelement, elementToWrap);
+    }
+
+    /**
+     * Initializes fields of the given page object with lazy proxies.
+     * <p/>
+     * Processes {@link org.openqa.selenium.support.FindBy},
+     * {@link org.openqa.selenium.support.FindBys} and {@link org.openqa.selenium.support.FindAll}
+     * annotations of the fields for setting the way of locating them.
+     * <p/>
+     * Fields to be proxied:
+     * <p/>
+     * <ul>
+     * <li>{@code WebElement}</li>
+     * <li>List of {@code WebElements}</li>
+     * <li>Block of elements ({@link LitElement} and its successors)</li>
+     * <li>Block of elements ({@link HtmlElement} and its successors)</li>
+     * <li>List of blocks</li>
+     * <li>Typified element ({@link ru.yandex.qatools.htmlelements.element.TypifiedElement} successors)</li>
+     * <li>List of typified elements</li>
+     * </ul>
+     *
+     * @param page          Page object to be initialized.
+     * @param searchContext The {@code WebDriver} instance that will be used to look up the elements.
+     */
+    public static void populatePageObject(Object page, SearchContext searchContext) {
+        populatePageObject(page, new HtmlElementLocatorFactory(searchContext));
+    }
+
+    /**
+     * Initializes fields of the given page object using specified locator factory.
+     *
+     * @param page           Page object to be initialized.
+     * @param locatorFactory Locator factory that will be used to locate elements.
+     */
+    public static void populatePageObject(Object page, CustomElementLocatorFactory locatorFactory) {
+        PageFactory.initElements(new LitElementDecorator(locatorFactory), page);
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/LitElementDecorator.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/LitElementDecorator.java
@@ -1,0 +1,94 @@
+package com.frameworkium.core.ui.litelements.loader.decorator;
+
+import com.frameworkium.core.ui.litelements.element.LitElement;
+import com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers.LitElementListNamedProxyHandler;
+import com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers.LitElementNamedProxyHandler;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+import ru.yandex.qatools.htmlelements.element.HtmlElement;
+import ru.yandex.qatools.htmlelements.loader.decorator.HtmlElementDecorator;
+import ru.yandex.qatools.htmlelements.pagefactory.CustomElementLocatorFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.util.List;
+
+import static com.frameworkium.core.ui.litelements.loader.LitElementLoader.createHtmlElement;
+import static com.frameworkium.core.ui.litelements.loader.LitElementLoader.createLitElement;
+import static com.frameworkium.core.ui.litelements.loader.decorator.ProxyFactoryLitElement.createLitElementListProxy;
+import static com.frameworkium.core.ui.litelements.utils.LitElementUtils.isLitElement;
+import static com.frameworkium.core.ui.litelements.utils.LitElementUtils.isLitElementList;
+import static ru.yandex.qatools.htmlelements.loader.decorator.ProxyFactory.createWebElementProxy;
+import static ru.yandex.qatools.htmlelements.utils.HtmlElementUtils.*;
+
+
+public class LitElementDecorator extends HtmlElementDecorator {
+
+    public LitElementDecorator(final CustomElementLocatorFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    public Object decorate(ClassLoader loader, Field field) {
+        try {
+            if (isLitElement(field)) {
+                return decorateLitElement(loader, field);
+            }
+            if (isTypifiedElement(field)) {
+                return decorateTypifiedElement(loader, field);
+            }
+            if (isHtmlElement(field)) {
+                return decorateHtmlElement(loader, field);
+            }
+            if (isWebElement(field) && !field.getName().equals("wrappedElement")) {
+                return decorateWebElement(loader, field);
+            }
+            if (isLitElementList(field)) {
+                return decorateLitElementList(loader, field);
+            }
+            if (isTypifiedElementList(field)) {
+                return decorateTypifiedElementList(loader, field);
+            }
+            if (isHtmlElementList(field)) {
+                return decorateHtmlElementList(loader, field);
+            }
+            if (isWebElementList(field)) {
+                return decorateWebElementList(loader, field);
+            }
+            return null;
+        } catch (ClassCastException ignore) {
+            return null; // See bug #94 and NonElementFieldsTest
+        }
+    }
+
+    protected <T extends LitElement> T decorateLitElement(ClassLoader loader, Field field) {
+        WebElement elementToWrap = decorateShadowedWebElement(loader, field);
+        return createLitElement((Class<T>) field.getType(), elementToWrap, getElementName(field));
+    }
+
+    protected WebElement decorateShadowedWebElement(ClassLoader loader, Field field) {
+        ElementLocator locator = factory.createLocator(field);
+        InvocationHandler handler = new LitElementNamedProxyHandler(locator, getElementName(field));
+
+        return createWebElementProxy(loader, handler);
+    }
+
+    protected <T extends LitElement> List<T> decorateLitElementList(ClassLoader loader, Field field) {
+        @SuppressWarnings("unchecked")
+        Class<T> elementClass = (Class<T>) getGenericParameterClass(field);
+        ElementLocator locator = factory.createLocator(field);
+        String name = getElementName(field);
+
+        InvocationHandler handler = new LitElementListNamedProxyHandler<>(elementClass, locator, name);
+
+        return createLitElementListProxy(loader, handler);
+    }
+
+    @Override
+    protected <T extends HtmlElement> T decorateHtmlElement(ClassLoader loader, Field field) {
+        WebElement elementToWrap = decorateWebElement(loader, field);
+
+        //noinspection unchecked
+        return createHtmlElement((Class<T>) field.getType(), elementToWrap, getElementName(field));
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/ProxyFactoryLitElement.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/ProxyFactoryLitElement.java
@@ -1,0 +1,16 @@
+package com.frameworkium.core.ui.litelements.loader.decorator;
+
+import com.frameworkium.core.ui.litelements.element.LitElement;
+import ru.yandex.qatools.htmlelements.loader.decorator.ProxyFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+public class ProxyFactoryLitElement extends ProxyFactory {
+
+    public static <T extends LitElement> List<T> createLitElementListProxy(ClassLoader loader,
+                                                                           InvocationHandler handler) {
+        return (List<T>) Proxy.newProxyInstance(loader, new Class[]{List.class}, handler);
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LitElementListNamedProxyHandler.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LitElementListNamedProxyHandler.java
@@ -1,0 +1,46 @@
+package com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers;
+
+import com.frameworkium.core.ui.litelements.element.LitElement;
+import com.frameworkium.core.ui.litelements.utils.ShadowDomUtil;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+import java.lang.reflect.*;
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.frameworkium.core.ui.litelements.loader.LitElementLoader.createLitElement;
+
+
+public class LitElementListNamedProxyHandler<T extends LitElement> implements InvocationHandler {
+    private final Class<T> elementClass;
+    private final ElementLocator locator;
+    private final String name;
+
+    public LitElementListNamedProxyHandler(Class<T> elementClass, ElementLocator locator, String name) {
+        this.elementClass = elementClass;
+        this.locator = locator;
+        this.name = name;
+    }
+
+    @Override
+    public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
+        if ("toString".equals(method.getName())) {
+            return name;
+        }
+
+        List<T> elements = new LinkedList<>();
+        int elementNumber = 0;
+        for (WebElement element : locator.findElements()) {
+            String newName = String.format("%s [%d]", name, elementNumber++);
+            elements.add(createLitElement(elementClass, ShadowDomUtil.getShadow(element), newName));
+        }
+
+        try {
+            return method.invoke(elements, objects);
+        } catch (InvocationTargetException e) {
+            // Unwrap the underlying exception
+            throw e.getCause();
+        }
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LitElementNamedProxyHandler.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LitElementNamedProxyHandler.java
@@ -1,0 +1,51 @@
+package com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers;
+
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+import java.lang.reflect.Method;
+import java.time.LocalTime;
+
+public class LitElementNamedProxyHandler extends LocatingLitElementHandler {
+
+    public static final int DEFAULT_TIMEOUT = 5;
+
+    private final long timeOutInSeconds;
+
+    private final String name;
+
+    public LitElementNamedProxyHandler(ElementLocator locator, String name) {
+        super(locator);
+        this.name = name;
+        this.timeOutInSeconds = Integer.getInteger("webdriver.timeouts.implicitlywait", DEFAULT_TIMEOUT);
+    }
+
+    @Override
+    public Object invoke(Object o, Method method, Object[] objects) throws Throwable {
+        if ("toString".equals(method.getName())) {
+            return name;
+        }
+
+        final LocalTime end = LocalTime.now().plusSeconds(timeOutInSeconds);
+
+        StaleElementReferenceException lastException;
+        do {
+            try {
+                return super.invoke(o, method, objects);
+            } catch (StaleElementReferenceException e) {
+                lastException = e;
+                this.waitFor();
+            }
+        }
+        while (LocalTime.now().isBefore(end));
+        throw lastException;
+    }
+
+    protected long sleepFor() {
+        return 500L;
+    }
+
+    private void waitFor() throws InterruptedException {
+        Thread.sleep(this.sleepFor());
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LocatingLitElementHandler.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/loader/decorator/proxyhandlers/LocatingLitElementHandler.java
@@ -1,0 +1,55 @@
+package com.frameworkium.core.ui.litelements.loader.decorator.proxyhandlers;
+
+import com.frameworkium.core.ui.litelements.utils.ShadowDomUtil;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.pagefactory.ElementLocator;
+
+import java.lang.reflect.*;
+
+public class LocatingLitElementHandler implements InvocationHandler {
+    protected final ElementLocator locator;
+
+    public LocatingLitElementHandler(ElementLocator locator) {
+        this.locator = locator;
+    }
+
+    /**
+     * Locates a litelement by shadowhost locator and returns the shadowroot
+     *
+     * @param object  is the proxy of the given shadow host
+     * @param method  is the method to be invoked by the proxied object
+     * @param objects is the arguments of {@code method}
+     * @return the shadowroot of given shadowhost
+     */
+    public Object invoke(Object object, Method method, Object[] objects) throws Throwable {
+        WebElement element;
+        WebElement shadowroot;
+
+        try {
+            element = locator.findElement();
+        } catch (NoSuchElementException e) {
+            if ("toString".equals(method.getName())) {
+                return "Proxy element for: " + locator.toString();
+            }
+            throw e;
+        }
+
+        shadowroot = ShadowDomUtil.getShadow(element);
+        if (shadowroot == null) {
+            throw new NoSuchElementException("No shadowroot found for " + locator.toString());
+        }
+
+
+        if ("getWrappedElement".equals(method.getName())) {
+            return element;
+        }
+
+        try {
+            return method.invoke(shadowroot, objects);
+        } catch (InvocationTargetException e) {
+            // Unwrap the underlying exception
+            throw e.getCause();
+        }
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/utils/LitElementUtils.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/utils/LitElementUtils.java
@@ -1,0 +1,47 @@
+package com.frameworkium.core.ui.litelements.utils;
+
+import com.frameworkium.core.ui.litelements.element.LitElement;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+import static ru.yandex.qatools.htmlelements.utils.HtmlElementUtils.getGenericParameterClass;
+
+public class LitElementUtils {
+
+    private LitElementUtils() {
+    }
+
+    public static boolean isLitElement(Field field) {
+        return isLitElement(field.getType());
+    }
+
+    public static boolean isLitElement(Class<?> clazz) {
+        return LitElement.class.isAssignableFrom(clazz);
+    }
+
+    public static <T> boolean isLitElement(T instance) {
+        return LitElement.class.isInstance(instance);
+    }
+
+    public static boolean isLitElementList(Field field) {
+        if (!isParametrizedList(field)) {
+            return false;
+        }
+        Class listParameterClass = getGenericParameterClass(field);
+        return isLitElement(listParameterClass);
+    }
+
+    private static boolean isParametrizedList(Field field) {
+        return isList(field) && hasGenericParameter(field);
+    }
+
+    private static boolean isList(Field field) {
+        return List.class.isAssignableFrom(field.getType());
+    }
+
+    private static boolean hasGenericParameter(Field field) {
+        return field.getGenericType() instanceof ParameterizedType;
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/litelements/utils/ShadowDomUtil.java
+++ b/src/main/java/com/frameworkium/core/ui/litelements/utils/ShadowDomUtil.java
@@ -1,0 +1,18 @@
+package com.frameworkium.core.ui.litelements.utils;
+
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebElement;
+
+import static com.frameworkium.core.ui.tests.BaseUITest.getWebDriver;
+
+public class ShadowDomUtil {
+
+    private ShadowDomUtil() {
+        throw new AssertionError("Utility class should not be instantiated");
+    }
+
+    public static WebElement getShadow(WebElement webElement) {
+        return (WebElement) ((JavascriptExecutor) getWebDriver())
+                .executeScript("return arguments[0].shadowRoot", webElement);
+    }
+}

--- a/src/main/java/com/frameworkium/core/ui/pages/BasePageExtra.java
+++ b/src/main/java/com/frameworkium/core/ui/pages/BasePageExtra.java
@@ -1,0 +1,12 @@
+package com.frameworkium.core.ui.pages;
+
+import com.frameworkium.core.ui.litelements.loader.LitElementLoader;
+import com.frameworkium.core.ui.pages.BasePage;
+
+public class BasePageExtra<T extends BasePage<T>> extends BasePage<T> {
+
+    @Override
+    protected void initPageObjectFields() {
+        LitElementLoader.populatePageObject(this, driver);
+    }
+}


### PR DESCRIPTION
This adds shadowDOM support specifically addressing Polymer LitElement liberal use of shadowDOM as part of web component encapsulation strategy
https://github.com/Polymer/lit-element

This closely follows `HtmlElement` usage model with the added bonus of automatically traversing through the shadowdom given a shadowhost

e.g.
```
@FindBy(css = "div.shadowhost")
// must point to a shadow host
private ShadowedElement shadowelement
```

```
public class ShadowedElement extends LitElement{ 
//litelement type will denote it is shadowed, and it will be taken care of by the proxy implementation
@FindBy(css = "div.button")
private WebElement myButton;

public WebElement getMyButton(){
   return myButton;
  }
}
```

```
shadowelement.getMyButton().click();
```

All shadowdom traversal logic is taken care of
This will support nested implementation of all known WebElement subclasses regardless of nesting order:
- WebElement
- HtmlElement
- TypifiedElement
- LitElement



