### PR TITLE
Update jacoco coverage test script and reporting setup to support codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,9 @@ script:
   # Allure report
   - mvn allure:report -B
 
+  # Support test reporting for Jacoco and code climate
+  - mvn test jacoco:report
+
 after_script:
   # Code coverage report
   - bash <(curl -s https://codecov.io/bash)

--- a/pom.xml
+++ b/pom.xml
@@ -434,4 +434,24 @@
     </plugins>
   </build>
 
+  <!--  Support test reporting for Jacoco and code climate-->
+  <!-- REFERENCE: https://medium.com/capital-one-tech/improve-java-code-with-unit-tests-and-jacoco-b342643736ed  -->
+  <!-- REFERENCE: https://github.com/TheoOkafor/mini-calendly-java -->
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <!-- select non-aggregate reports -->
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
This PR updates the jacoco coverage test script and reporting setup to support Codeclimate

REFERENCES:
- https://medium.com/capital-one-tech/improve-java-code-with-unit-tests-and-jacoco-b342643736ed
- https://github.com/TheoOkafor/mini-calendly-java (This is my personal repo where I have this setup working)